### PR TITLE
fix to enable load.balancing option

### DIFF
--- a/R/parallelMap.R
+++ b/R/parallelMap.R
@@ -112,7 +112,7 @@ parallelMap = function(fun, ..., more.args = list(), simplify = FALSE, use.names
     } else if (isModeSocket() || isModeMPI()) {
       more.args = c(list(.fun = fun, .logdir = logdir), more.args)
       if (load.balancing) {
-        res = clusterMapLB(cl = NULL, slaveWrapper, ...,  .i = iters, MoreArgs = more.args, SIMPLIFY = FALSE, USE.NAMES = FALSE)
+        res = clusterMapLB(cl = NULL, slaveWrapper, ...,  .i = iters, MoreArgs = more.args)
       } else {
         res = clusterMap(cl = NULL, slaveWrapper, ..., .i = iters, MoreArgs = more.args, SIMPLIFY = FALSE, USE.NAMES = FALSE)
       }

--- a/R/parallelStart.R
+++ b/R/parallelStart.R
@@ -84,7 +84,7 @@
 #'   \code{mc.silent} and \code{mc.cleanup} are supported for multicore).
 #' @return Nothing.
 #' @export
-parallelStart = function(mode, cpus, socket.hosts, bj.resources = list(), bt.resources = list(), logging, storagedir, level, load.balancing = FALSE,
+parallelStart = function(mode, cpus, socket.hosts, bj.resources = list(), logging, storagedir, level, load.balancing = FALSE,
   show.info, suppress.local.errors = FALSE, ...) {
   # if stop was not called, warn and do it now
   if (isStatusStarted() && !isModeLocal()) {
@@ -109,14 +109,13 @@ parallelStart = function(mode, cpus, socket.hosts, bj.resources = list(), bt.res
   storagedir = getPMDefOptStorageDir(storagedir)
   # defaults are in batchjobs conf
   assertList(bj.resources)
-  assertList(bt.resources)
   assertFlag(load.balancing)
   show.info = getPMDefOptShowInfo(show.info)
 
   # multicore not supported on windows
   if (mode == MODE_MULTICORE && .Platform$OS.type == "windows")
     stop("Multicore mode not supported on windows!")
-  assertDirectory(storagedir, access = "w")
+  assertDirectoryExists(storagedir, access = "w")
 
   # store options for session, we already need them for helper funs below
   options(parallelMap.mode = mode)
@@ -124,7 +123,6 @@ parallelStart = function(mode, cpus, socket.hosts, bj.resources = list(), bt.res
   options(parallelMap.logging = logging)
   options(parallelMap.storagedir = storagedir)
   options(parallelMap.bj.resources = bj.resources)
-  options(parallelMap.bt.resources = bt.resources)
   options(parallelMap.load.balancing = load.balancing)
   options(parallelMap.show.info = show.info)
   options(parallelMap.status = STATUS_STARTED)
@@ -184,13 +182,7 @@ parallelStart = function(mode, cpus, socket.hosts, bj.resources = list(), bt.res
     suppressMessages({
       reg = BatchJobs::makeRegistry(id = basename(fd), file.dir = fd, work.dir = wd)
     })
-  } else if (isModeBatchtools()) {
-    fd = getBatchtoolsNewRegFileDir()
-    wd = getwd()
-    suppressMessages({
-      reg = batchtools::makeRegistry(file.dir = fd, work.dir = wd)
-    })
-  }
+  } 
   invisible(NULL)
 }
 
@@ -227,11 +219,4 @@ parallelStartMPI = function(cpus, logging, storagedir, level, load.balancing = F
 parallelStartBatchJobs = function(bj.resources = list(), logging, storagedir, level, show.info, ...) {
   parallelStart(mode = MODE_BATCHJOBS, level = level, logging = logging,
     storagedir = storagedir, bj.resources = bj.resources, show.info = show.info, ...)
-}
-
-#' @export
-#' @rdname parallelStart
-parallelStartBatchtools = function(bt.resources = list(), logging, storagedir, level, show.info, ...) {
-  parallelStart(mode = MODE_BATCHTOOLS, level = level, logging = logging,
-    storagedir = storagedir, bt.resources = bt.resources, show.info = show.info, ...)
 }

--- a/R/parallelStart.R
+++ b/R/parallelStart.R
@@ -182,7 +182,7 @@ parallelStart = function(mode, cpus, socket.hosts, bj.resources = list(), loggin
     suppressMessages({
       reg = BatchJobs::makeRegistry(id = basename(fd), file.dir = fd, work.dir = wd)
     })
-  } 
+  }
   invisible(NULL)
 }
 

--- a/R/parallelStart.R
+++ b/R/parallelStart.R
@@ -34,7 +34,7 @@
 #'   you want processes on multiple machines use \code{socket.hosts}.
 #'   Default is the option \code{parallelMap.default.cpus} or, if not set,
 #'   \code{\link[parallel]{detectCores}} for multicore mode,
-#'   \code{\link[Rmpi]{mpi.universe.size}} for mpi mode
+#'   \code{max(1, \link[Rmpi]{mpi.universe.size} - 1)} for mpi mode
 #'   and 1 for socket mode.
 #' @param socket.hosts [\code{character}]\cr
 #'   Only used in socket mode, otherwise ignored.

--- a/man/parallelStart.Rd
+++ b/man/parallelStart.Rd
@@ -15,14 +15,14 @@ parallelStart(mode, cpus, socket.hosts, bj.resources = list(), logging,
 
 parallelStartLocal(show.info, suppress.local.errors = FALSE, ...)
 
-parallelStartMulticore(cpus, logging, storagedir, level, load.balancing,
-  show.info, ...)
+parallelStartMulticore(cpus, logging, storagedir, level,
+  load.balancing = FALSE, show.info, ...)
 
 parallelStartSocket(cpus, socket.hosts, logging, storagedir, level,
-  load.balancing, show.info, ...)
+  load.balancing = FALSE, show.info, ...)
 
-parallelStartMPI(cpus, logging, storagedir, level, load.balancing, show.info,
-  ...)
+parallelStartMPI(cpus, logging, storagedir, level, load.balancing = FALSE,
+  show.info, ...)
 
 parallelStartBatchJobs(bj.resources = list(), logging, storagedir, level,
   show.info, ...)

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -141,4 +141,21 @@ partest6 = function(slave.error.test) {
   }
 }
 
+# test that load balancing is active
+partest7 = function() {
+   f = function(i) {
+      if (i == 1) {
+        Sys.sleep(9)
+      } else {
+        Sys.sleep(1)
+      }
+      return(i)
+    }
+    st = system.time({
+      ys = parallelMap(f, 1:10, simplify = TRUE)
+    })
+    expect_equal(ys, 1:10)
+    expect_true(st[3L] < 10)
+}
+
 

--- a/tests/testthat/test_mpi.R
+++ b/tests/testthat/test_mpi.R
@@ -31,5 +31,9 @@ if (interactive()) {
     parallelStartMPI(2)
     partest6(slave.error.test=TRUE)
     parallelStop()
+
+    parallelStartMPI(2, load.balancing = TRUE)
+    partest7()
+    parallelStop()
   })
 }

--- a/tests/testthat/test_multicore.R
+++ b/tests/testthat/test_multicore.R
@@ -33,21 +33,10 @@ if (isExpensiveExampleOk()) {
     parallelStartMulticore(2)
     partest6(slave.error.test = FALSE)
     parallelStop()
-  })
 
-  test_that("multicore does not run sequentially", {
-    f = function(i) {
-      Sys.sleep(5)
-      i
-    }
-
-    parallelStartMulticore(cpus = 2L)
-    st = system.time({
-      ys = parallelMap(f, 1:2, simplify = TRUE)
-    })
+    parallelStartMulticore(2, load.balancing = TRUE)
+    partest7()
     parallelStop()
 
-    expect_equal(ys, 1:2)
-    expect_true(st[3L] < 8)
   })
 }


### PR DESCRIPTION
It was not possible to enable load.balancing option for the following functions even if load.balancing was set to TRUE:
parallelStartMulticore
parallelStartSocket
parallelStartMPI
Modifications (line 206 - 223) are independent from batchtools 